### PR TITLE
Fixes: El corrector ortográfico marca inválidas palabras con puntuación

### DIFF
--- a/speller.rb
+++ b/speller.rb
@@ -3,6 +3,7 @@ require 'sinatra/cross_origin'
 require 'ffi/aspell'
 require 'json'
 
+# Sinatra app for check spelling
 class SpellerApp < Sinatra::Base
   register Sinatra::CrossOrigin
 
@@ -17,30 +18,44 @@ class SpellerApp < Sinatra::Base
   end
 
   options '/spell' do
-    ""
+    ''
   end
-
 end
 
 # A class used to use aspell to spellcheck a text
 class Speller
   def self.check(words, lang, max_suggestions = 10)
     return if words.nil?
-    lang = 'es' unless %w(es en pt).include?(lang)
-    lang = 'pt_BR' if lang == 'pt'
+
+    lang = ensure_lang(lang)
     speller = FFI::Aspell::Speller.new(lang)
+
     pos = 0
     words.split.map do |word|
-      element = correct_word(speller, word, max_suggestions, pos)
+      element = correct_word(speller, clean_word(word), max_suggestions, pos)
       pos += (word.length + 1)
       element
     end.compact
   end
 
+  def self.ensure_lang(lang)
+    lang = 'es' unless %w[es en pt].include?(lang)
+    lang = 'pt_BR' if lang == 'pt'
+    lang
+  end
+
+  def self.clean_word(word)
+    word.gsub(/^[[:punct:]]/,'')
+        .gsub(/[[:punct:]]$/,'')
+  end
+
   def self.correct_word(speller, word, max_suggestions, pos)
     return if speller.correct?(word)
+
     suggestions = speller.suggestions(word).first(max_suggestions)
-    suggestions.map! {|suggestion| suggestion.force_encoding("ISO-8859-1").encode("UTF-8")}
+    suggestions.map! do |suggestion|
+      suggestion.force_encoding('ISO-8859-1').encode('UTF-8')
+    end
     suggestions_to_hash(word, pos, suggestions)
   end
 


### PR DESCRIPTION
Referencia: https://lemontech.atlassian.net/browse/TF-2959 

## Problema
Al escribir cualquier palabra con puntuación el corrector la interpreta como inválida. Incluso textos entre comillas.

![screen shot 2019-02-26 at 16 29 10](https://user-images.githubusercontent.com/445798/53440839-3a99de80-39e4-11e9-85e7-6b5c44abad21.png)


## Solución 
Se limpia cada palabra antes de revisarla en el diccionario, sacando la puntuación del comienzo y fin de cada palabra, no se realiza al string completo ya que se debe mantener la posición de comienzo de la palabra, además como se debe hacer split del texto completo no es conveniente reemplazar todos los caracteres inválidos con espacio. 

## Q&A 
- Envíe textos con puntuación, debería marcar como inválidos solo los que están mal escritos: 
 
![screen shot 2019-02-26 at 16 15 31](https://user-images.githubusercontent.com/445798/53440849-41285600-39e4-11e9-825a-670ce54bc8e0.png)

![screen shot 2019-02-26 at 16 15 35](https://user-images.githubusercontent.com/445798/53440728-00304180-39e4-11e9-8748-6288866ef5f2.png)

- Textos con puntuación intermedia también son y deben ser inválidos 👀  
![screen shot 2019-02-26 at 16 25 23](https://user-images.githubusercontent.com/445798/53440738-045c5f00-39e4-11e9-86f0-4d71a4596f04.png)

![screen shot 2019-02-26 at 16 25 27](https://user-images.githubusercontent.com/445798/53440781-1807c580-39e4-11e9-90bb-a6285c42db5e.png)

- Textos entre comillas deben ser aceptados
![screen shot 2019-02-26 at 16 25 49](https://user-images.githubusercontent.com/445798/53440820-2ce45900-39e4-11e9-8d27-e7c1a9417628.png)

